### PR TITLE
Update OXID eShop Coding Standards Definition for CodeSniffer 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See OXID eShop coding standards documentation at http://wiki.oxidforge.org/Codin
 
 ##Requirements
 * PHP 5.3+
-* PHP Codesniffer 1.5+
+* PHP Codesniffer 2.1+
 
 ##Installation
 Installation is as easy as checking out the repository to the correct location within PHP_CodeSniffer's directory structure.

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -104,17 +104,6 @@ class Oxid_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_Fi
             $start = $phpcsFile->findPrevious(T_COMMENT, ($commentEnd - 1), null, true);
         }
 
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $start, null, true);
-        if ($tokens[$prev]['code'] === T_OPEN_TAG) {
-            $prevOpen = $phpcsFile->findPrevious(T_OPEN_TAG, ($prev - 1));
-            if ($prevOpen === false) {
-                // This is a comment directly after the first open tag,
-                // so probably a file comment.
-                $phpcsFile->addError('Missing class doc comment', $stackPtr, 'Missing');
-                return;
-            }
-        }
-
         if ($tokens[$commentEnd]['code'] === T_COMMENT) {
             $phpcsFile->addError('You must use "/**" style comments for a class comment', $stackPtr, 'WrongStyle');
             return;

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -125,33 +125,4 @@ class Oxid_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_Fi
 
     }//end process()
 
-
-    /**
-     * Process the version tag.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                $tags      The tokens for these tags.
-     *
-     * @return void
-     */
-    protected function processVersion(PHP_CodeSniffer_File $phpcsFile, array $tags)
-    {
-        $tokens = $phpcsFile->getTokens();
-        foreach ($tags as $tag) {
-            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
-                // No content.
-                continue;
-            }
-
-            $content = $tokens[($tag + 2)]['content'];
-            if ((strstr($content, 'Release:') === false)) {
-                $error = 'Invalid version "%s" in doc comment; consider "Release: <package_version>" instead';
-                $data  = array($content);
-                $phpcsFile->addWarning($error, $tag, 'InvalidVersion', $data);
-            }
-        }
-
-    }//end processVersion()
-
-
 }//end class

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -49,6 +49,8 @@
 class Oxid_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_FileCommentSniff
 {
 
+    protected $tags = array();
+
     /**
      * Returns an array of tokens this test wants to listen for.
      *

--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -74,12 +74,11 @@ class Oxid_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
             if (empty($content) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING) {
                 $error = 'Return type missing for @return tag in function comment';
                 $phpcsFile->addError($error, $return, 'MissingReturnType');
-            }
-            elseif (!$this->functionHasReturnStatement($phpcsFile, $stackPtr)) {
+            } elseif (!$this->functionHasReturnStatement($phpcsFile, $stackPtr)) {
                 $error = 'Function return type is set, but function has no return statement';
                 $phpcsFile->addError($error, $return, 'InvalidNoReturn');
             }
-        } elseif ( $this->functionHasReturnStatement($phpcsFile, $stackPtr) ) {
+        } elseif ($this->functionHasReturnStatement($phpcsFile, $stackPtr)) {
             $error = 'Missing @return tag in function comment.';
             $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
         }//end if
@@ -89,10 +88,9 @@ class Oxid_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
     /**
      * Search if Function has a Return Statement
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
      *
      * @return bool
      */
@@ -102,7 +100,8 @@ class Oxid_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
         $sFunctionToken = $tokens[$stackPtr];
 
         if (isset($sFunctionToken['scope_opener']) && isset($sFunctionToken['scope_closer'])
-            && $phpcsFile->findNext(T_RETURN, $sFunctionToken['scope_opener'], $sFunctionToken['scope_closer']) !== false) {
+            && $phpcsFile->findNext(T_RETURN, $sFunctionToken['scope_opener'], $sFunctionToken['scope_closer']) !== false
+        ) {
             return true;
         }
 

--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -34,86 +34,6 @@
  */
 class Oxid_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
 {
-
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(T_FUNCTION);
-
-    }//end register()
-
-
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
-        $find[] = T_WHITESPACE;
-
-        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            // Inline comments might just be closing comments for
-            // control structures or functions instead of function comments
-            // using the wrong comment type. If there is other code on the line,
-            // assume they relate to that code.
-            $prev = $phpcsFile->findPrevious($find, ($commentEnd - 1), null, true);
-            if ($prev !== false && $tokens[$prev]['line'] === $tokens[$commentEnd]['line']) {
-                $commentEnd = $prev;
-            }
-        }
-
-        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-            && $tokens[$commentEnd]['code'] !== T_COMMENT
-        ) {
-            $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
-            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'no');
-            return;
-        } else {
-            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'yes');
-        }
-
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            $phpcsFile->addError('You must use "/**" style comments for a function comment', $stackPtr, 'WrongStyle');
-            return;
-        }
-
-        if ($tokens[$commentEnd]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
-            $error = 'There must be no blank lines after the function comment';
-            $phpcsFile->addError($error, $commentEnd, 'SpacingAfter');
-        }
-
-        $commentStart = $tokens[$commentEnd]['comment_opener'];
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            if ($tokens[$tag]['content'] === '@see') {
-                // Make sure the tag isn't empty.
-                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
-                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
-                    $error = 'Content missing for @see tag in function comment';
-                    $phpcsFile->addError($error, $tag, 'EmptySees');
-                }
-            }
-        }
-
-        $this->processReturn($phpcsFile, $stackPtr, $commentStart);
-        $this->processThrows($phpcsFile, $stackPtr, $commentStart);
-        $this->processParams($phpcsFile, $stackPtr, $commentStart);
-
-    }//end process()
-
-
     /**
      * Process the return comment of this function comment.
      *
@@ -155,234 +75,38 @@ class Oxid_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
                 $error = 'Return type missing for @return tag in function comment';
                 $phpcsFile->addError($error, $return, 'MissingReturnType');
             }
-        } else {
-            $error = 'Missing @return tag in function comment';
+            elseif (!$this->functionHasReturnStatement($phpcsFile, $stackPtr)) {
+                $error = 'Function return type is set, but function has no return statement';
+                $phpcsFile->addError($error, $return, 'InvalidNoReturn');
+            }
+        } elseif ( $this->functionHasReturnStatement($phpcsFile, $stackPtr) ) {
+            $error = 'Missing @return tag in function comment.';
             $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
         }//end if
 
     }//end processReturn()
 
-
     /**
-     * Process any throw tags that this function comment has.
+     * Search if Function has a Return Statement
      *
      * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                  $stackPtr     The position of the current token
      *                                           in the stack passed in $tokens.
      * @param int                  $commentStart The position in the stack where the comment started.
      *
-     * @return void
+     * @return bool
      */
-    protected function processThrows(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+    protected function functionHasReturnStatement(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+        $sFunctionToken = $tokens[$stackPtr];
 
-        $throws = array();
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            if ($tokens[$tag]['content'] !== '@throws') {
-                continue;
-            }
-
-            $exception = null;
-            $comment   = null;
-            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
-                $matches = array();
-                preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($tag + 2)]['content'], $matches);
-                $exception = $matches[1];
-                if (isset($matches[2]) === true) {
-                    $comment = $matches[2];
-                }
-            }
-
-            if ($exception === null) {
-                $error = 'Exception type missing for @throws tag in function comment';
-                $phpcsFile->addError($error, $tag, 'InvalidThrows');
-            }
-        }//end foreach
-
-    }//end processThrows()
-
-
-    /**
-     * Process the function parameter comments.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
-     *
-     * @return void
-     */
-    protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        $params  = array();
-        $maxType = 0;
-        $maxVar  = 0;
-        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
-            if ($tokens[$tag]['content'] !== '@param') {
-                continue;
-            }
-
-            $type      = '';
-            $typeSpace = 0;
-            $var       = '';
-            $varSpace  = 0;
-            $comment   = '';
-            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
-                $matches = array();
-                preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
-
-                $typeLen   = strlen($matches[1]);
-                $type      = trim($matches[1]);
-                $typeSpace = ($typeLen - strlen($type));
-                $typeLen   = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
-                }
-
-                if (isset($matches[2]) === true) {
-                    $var    = $matches[2];
-                    $varLen = strlen($var);
-                    if ($varLen > $maxVar) {
-                        $maxVar = $varLen;
-                    }
-
-                    if (isset($matches[4]) === true) {
-                        $varSpace = strlen($matches[3]);
-                        $comment  = $matches[4];
-
-                        // Any strings until the next tag belong to this comment.
-                        if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
-                            $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
-                        } else {
-                            $end = $tokens[$commentStart]['comment_closer'];
-                        }
-
-                        for ($i = ($tag + 3); $i < $end; $i++) {
-                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                                $comment .= ' '.$tokens[$i]['content'];
-                            }
-                        }
-                    } else {
-                        $error = 'Missing parameter comment';
-                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
-                    }
-                } else {
-                    $error = 'Missing parameter name';
-                    $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }//end if
-            } else {
-                $error = 'Missing parameter type';
-                $phpcsFile->addError($error, $tag, 'MissingParamType');
-            }//end if
-
-            $params[] = array(
-                         'tag'        => $tag,
-                         'type'       => $type,
-                         'var'        => $var,
-                         'comment'    => $comment,
-                         'type_space' => $typeSpace,
-                         'var_space'  => $varSpace,
-                        );
-        }//end foreach
-
-        $realParams  = $phpcsFile->getMethodParameters($stackPtr);
-        $foundParams = array();
-
-        foreach ($params as $pos => $param) {
-            if ($param['var'] === '') {
-                continue;
-            }
-
-            $foundParams[] = $param['var'];
-
-            // Check number of spaces after the type.
-            $spaces = ($maxType - strlen($param['type']) + 1);
-            if ($param['type_space'] !== $spaces) {
-                $error = 'Expected %s spaces after parameter type; %s found';
-                $data  = array(
-                          $spaces,
-                          $param['type_space'],
-                         );
-
-                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamType', $data);
-                if ($fix === true) {
-                    $content  = $param['type'];
-                    $content .= str_repeat(' ', $spaces);
-                    $content .= $param['var'];
-                    $content .= str_repeat(' ', $param['var_space']);
-                    $content .= $param['comment'];
-                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
-                }
-            }
-
-            // Make sure the param name is correct.
-            if (isset($realParams[$pos]) === true) {
-                $realName = $realParams[$pos]['name'];
-                if ($realName !== $param['var']) {
-                    $code = 'ParamNameNoMatch';
-                    $data = array(
-                             $param['var'],
-                             $realName,
-                            );
-
-                    $error = 'Doc comment for parameter %s does not match ';
-                    if (strtolower($param['var']) === strtolower($realName)) {
-                        $error .= 'case of ';
-                        $code   = 'ParamNameNoCaseMatch';
-                    }
-
-                    $error .= 'actual variable name %s';
-
-                    $phpcsFile->addError($error, $param['tag'], $code, $data);
-                }
-            } else if (substr($param['var'], -4) !== ',...') {
-                // We must have an extra parameter comment.
-                $error = 'Superfluous parameter comment';
-                $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
-            }//end if
-
-            if ($param['comment'] === '') {
-                continue;
-            }
-
-            // Check number of spaces after the var name.
-            $spaces = ($maxVar - strlen($param['var']) + 1);
-            if ($param['var_space'] !== $spaces) {
-                $error = 'Expected %s spaces after parameter name; %s found';
-                $data  = array(
-                          $spaces,
-                          $param['var_space'],
-                         );
-
-                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamName', $data);
-                if ($fix === true) {
-                    $content  = $param['type'];
-                    $content .= str_repeat(' ', $param['type_space']);
-                    $content .= $param['var'];
-                    $content .= str_repeat(' ', $spaces);
-                    $content .= $param['comment'];
-                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
-                }
-            }
-        }//end foreach
-
-        $realNames = array();
-        foreach ($realParams as $realParam) {
-            $realNames[] = $realParam['name'];
+        if (isset($sFunctionToken['scope_opener']) && isset($sFunctionToken['scope_closer'])
+            && $phpcsFile->findNext(T_RETURN, $sFunctionToken['scope_opener'], $sFunctionToken['scope_closer']) !== false) {
+            return true;
         }
 
-        // Report missing comments.
-        $diff = array_diff($realNames, $foundParams);
-        foreach ($diff as $neededParam) {
-            $error = 'Doc comment for parameter "%s" missing';
-            $data  = array($neededParam);
-            $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
-        }
-
-    }//end processParams()
-
+        return false;
+    }//end functionHasReturnStatement()
 
 }//end class

--- a/Sniffs/Functions/ForbiddenFunctionsSniff.php
+++ b/Sniffs/Functions/ForbiddenFunctionsSniff.php
@@ -45,7 +45,7 @@ class Oxid_Sniffs_Functions_ForbiddenFunctionsSniff extends Generic_Sniffs_PHP_F
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
         'var_dump'   => null,
         'sizeof'     => 'count',
         'delete'     => 'unset',


### PR DESCRIPTION
I have updated OXID eShop Coding Standards Definition for CodeSniffer 2.1.0 that include `phpcbf`