### PR TITLE
Exit with correct return code we get back from phpcs, otherwise there…

### DIFF
--- a/bin/phpcsoxid
+++ b/bin/phpcsoxid
@@ -64,4 +64,5 @@ if (!$sourceFromParams) {
     }
 }
 
-passthru($command);
+passthru($command, $ret);
+exit($ret);


### PR DESCRIPTION
… is no way to stop execution e.g. in a CI environment.
Without the return code, the execution will never stop, even if phpcs returns errors. The bash return code which you can check with e.g. "echo $?" will always be 0, indicating "no errors".