### PR TITLE
add option to use sniffer for vendor install in windows

### DIFF
--- a/bin/phpcsoxid
+++ b/bin/phpcsoxid
@@ -22,18 +22,14 @@
 
 $scriptPath = array_shift($argv);
 $binDir = dirname(realpath($scriptPath));
-$dirSep = "/";
-if (substr(PHP_OS, 0, 3) === 'WIN') {
-    $dirSep = "\\\\";
-}
 
 // if installed by shop composer install
-if (preg_match("@vendor${dirSep}bin$@si", $binDir, $matches)) {
+if (preg_match("@vendor/bin$@si", $binDir, $matches)) {
     $phpCs = "$binDir/phpcs";
     $source = $binDir . "/../../";
     $standard = $binDir . "/../oxid-esales/coding-standards/Oxid";
 
-} elseif (preg_match("@${dirSep}vendor${dirSep}oxid-esales${dirSep}coding-standards${dirSep}bin$@si", $binDir, $matches)) {
+} elseif (preg_match("@.vendor.oxid-esales.coding-standards.bin$@si", $binDir, $matches)) {
     $phpCs = $binDir . "/../../../../vendor/bin/phpcs";
     $source = $binDir . "/../../../../";
     $standard = $binDir . "/../Oxid";

--- a/bin/phpcsoxid
+++ b/bin/phpcsoxid
@@ -27,8 +27,12 @@ $binDir = dirname($scriptPath);
 if (!preg_match("@vendor/bin$@si", $binDir, $matches)) {
     // overwrite for binDir variable with real path!
     $binDir = dirname(realpath($scriptPath));
-
     $phpCs = "$binDir/../vendor/bin/phpcs";
+
+    if (substr(PHP_OS, 0, 3) === 'WIN') {
+        $phpCs = $binDir ."/../../../../vendor/bin/phpcs";
+    }
+
     $standard = $binDir . "/../Oxid";
 
 // if installed by shop composer install

--- a/bin/phpcsoxid
+++ b/bin/phpcsoxid
@@ -21,15 +21,19 @@
  */
 
 $scriptPath = array_shift($argv);
-$binDir = dirname($scriptPath);
+$binDir = dirname(realpath($scriptPath));
+$dirSep = "/";
+if (substr(PHP_OS, 0, 3) === 'WIN') {
+    $dirSep = "\\\\";
+}
 
 // if installed by shop composer install
-if (preg_match("@vendor/bin$@si", $binDir, $matches)) {
+if (preg_match("@vendor${dirSep}bin$@si", $binDir, $matches)) {
     $phpCs = "$binDir/phpcs";
     $source = $binDir . "/../../";
     $standard = $binDir . "/../oxid-esales/coding-standards/Oxid";
 
-} elseif (preg_match("@/vendor/oxid-esales/coding-standards/bin$@si", $binDir, $matches)) {
+} elseif (preg_match("@${dirSep}vendor${dirSep}oxid-esales${dirSep}coding-standards${dirSep}bin$@si", $binDir, $matches)) {
     $phpCs = $binDir . "/../../../../vendor/bin/phpcs";
     $source = $binDir . "/../../../../";
     $standard = $binDir . "/../Oxid";

--- a/bin/phpcsoxid
+++ b/bin/phpcsoxid
@@ -23,19 +23,23 @@
 $scriptPath = array_shift($argv);
 $binDir = dirname($scriptPath);
 
-// check if installed by coding standards repository checkout
-if (!preg_match("@vendor/bin$@si", $binDir, $matches)) {
-    // overwrite for binDir variable with real path!
-    $binDir = dirname(realpath($scriptPath));
+// if installed by shop composer install
+if (preg_match("@vendor/bin$@si", $binDir, $matches)) {
+    $phpCs = "$binDir/phpcs";
+    $source = $binDir . "/../../";
+    $standard = $binDir . "/../oxid-esales/coding-standards/Oxid";
 
-    $phpCs = "$binDir/../vendor/bin/phpcs";
+} elseif (preg_match("@/vendor/oxid-esales/coding-standards/bin$@si", $binDir, $matches)) {
+    $phpCs = $binDir . "/../../../../vendor/bin/phpcs";
+    $source = $binDir . "/../../../../";
     $standard = $binDir . "/../Oxid";
 
-// if installed by shop composer install
+// if installed by coding standards repository checkout
 } else {
-    $phpCs = "$binDir/phpcs";
-    $standard = $binDir . "/../oxid-esales/coding-standards/Oxid";
-    $source = $binDir . "/../../";
+    // overwrite for binDir variable with real path!
+    $binDir = dirname(realpath($scriptPath));
+    $phpCs = "$binDir/../vendor/bin/phpcs";
+    $standard = $binDir . "/../Oxid";
 }
 
 // checking if phpcs can be found


### PR DESCRIPTION
When installing the coding standards via the composer installation in the shop root folder in windows the sniffer will not work. I fixed the path to the phpcs file for a installation via windows.